### PR TITLE
IBX-8139: Dropped class_alias BC layer statements from all classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     },
     "autoload": {
         "psr-4": {
-            "EzSystems\\EzPlatformAdminUiAssetsBundle\\": "/",
             "Ibexa\\Bundle\\AdminUiAssets\\": "src/bundle/"
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "ibexa/admin-ui-assets",
     "description": "External assets dependencies for Ibexa AdminUI",
-    "license": "GPL-2.0",
+    "license": "(GPL-2.0-only or proprietary)",
     "replace": {
         "ezsystems/ezplatform-admin-ui-assets": "*"
     },

--- a/src/bundle/IbexaAdminUiAssetsBundle.php
+++ b/src/bundle/IbexaAdminUiAssetsBundle.php
@@ -7,5 +7,3 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 class IbexaAdminUiAssetsBundle extends Bundle
 {
 }
-
-class_alias(IbexaAdminUiAssetsBundle::class, 'EzSystems\EzPlatformAdminUiAssetsBundle\EzPlatformAdminUiAssetsBundle');


### PR DESCRIPTION
> [!WARNING]
> # Drop TMP commit before merging

| :ticket: Issue | IBX-8139 |
|----------------|-----------|

#### Description:

Dropped `ez_class` BC layer statements from all classes using https://github.com/ibexa/rector/pull/2

Additionally, fixed incorrect license string in `composer.json`.

#### For QA:

No QA needed

#### Documentation:

Document that our BC layer has been dropped
